### PR TITLE
Add parameter to try..catch

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -26,5 +26,5 @@ function findReadme (dir) {
 function tryRead (filePath) {
   try {
     return fs.readFileSync(filePath, 'utf8')
-  } catch {}
+  } catch (e) {}
 }


### PR DESCRIPTION
This change will add support for Node.js v8 LTS release.

Without it following error occurs on v8:
```
/Users/secondfry/.nvm/versions/node/v8.17.0/lib/node_modules/nls/lib/read.js:29
  } catch {}
          ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/secondfry/.nvm/versions/node/v8.17.0/lib/node_modules/nls/lib/nls:7:14)
```