### PR TITLE
Add --prod and --dev flags to nls deps command

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -3,20 +3,20 @@ import kleur from 'kleur'
 import columnify from 'columnify'
 import { loadPackageJson } from './utils.js'
 
-export default function deps (cwd) {
+export default function deps (cwd, filter) {
   const { dependencies, devDependencies, optionalDependencies } = loadPackageJson(cwd)
 
   let depsData = []
 
-  if (dependencies) {
+  if (dependencies && (!filter || filter === 'prod')) {
     depsData = depsData.concat(formatDepsData(cwd, dependencies, 'dep'))
   }
 
-  if (devDependencies) {
+  if (devDependencies && (!filter || filter === 'dev')) {
     depsData = depsData.concat(formatDepsData(cwd, devDependencies, 'dev'))
   }
 
-  if (optionalDependencies) {
+  if (optionalDependencies && (!filter || filter === 'prod')) {
     depsData = depsData.concat(formatDepsData(cwd, optionalDependencies, 'optional'))
   }
 

--- a/lib/nls.js
+++ b/lib/nls.js
@@ -24,6 +24,7 @@ const helpText = `
 
     $ nls                     ${kleur.dim('List available npm scripts')}
     $ nls deps                ${kleur.dim('List dependencies table (d for short)')}
+                              ${kleur.dim('(--prod for production, --dev for development)')}
     $ nls view [prop-path]    ${kleur.dim('Extract info from package.json (v for short)')}
     $ nls read <package-name> ${kleur.dim('Print readme file from a dependency (r for short)')}
     $ nls why <package-name>  ${kleur.dim('Identify why a package has been installed (w for short)')}
@@ -47,7 +48,7 @@ const helpText = `
 `
 
 const args = mri(process.argv.slice(2), {
-  boolean: ['dir', 'help', 'version'],
+  boolean: ['dir', 'help', 'version', 'prod', 'dev'],
   alias: {
     d: 'dir',
     h: 'help',
@@ -61,7 +62,7 @@ main(args).catch(err => {
   console.error(createErrorMessage(err))
 })
 
-async function main ({ dir, help, version, _: rest }) {
+async function main ({ dir, help, version, prod, dev, _: rest }) {
   if (help) {
     return console.info(helpText)
   }
@@ -86,7 +87,10 @@ async function main ({ dir, help, version, _: rest }) {
       return view(cwd, ...params)
     case 'd':
     case 'deps':
-      return deps(cwd)
+      if (prod && dev) {
+        throw new Error('Cannot use both --prod and --dev')
+      }
+      return deps(cwd, prod ? 'prod' : (dev ? 'dev' : undefined))
   }
 
   const guessCwd = path.join(cwd, rest[0] || '')

--- a/test/more.spec.js
+++ b/test/more.spec.js
@@ -87,6 +87,29 @@ test('runs `deps`', async () => {
   assert.match(stdout, /pkg-c/)
 })
 
+test('runs `deps --prod`', async () => {
+  const { stdout } = await cli(['deps', '--prod'], { cwd: path.join(fixtureDir, 'deps-project') })
+  assert.match(stdout, /pkg-a/)
+  assert.match(stdout, /pkg-c/)
+  assert.doesNotMatch(stdout, /pkg-b/)
+})
+
+test('runs `deps --dev`', async () => {
+  const { stdout } = await cli(['deps', '--dev'], { cwd: path.join(fixtureDir, 'deps-project') })
+  assert.match(stdout, /pkg-b/)
+  assert.doesNotMatch(stdout, /pkg-a/)
+  assert.doesNotMatch(stdout, /pkg-c/)
+})
+
+test('runs `deps --prod --dev` fails', async () => {
+  try {
+    await cli(['deps', '--prod', '--dev'], { cwd: path.join(fixtureDir, 'deps-project') })
+    assert.fail('Should have failed')
+  } catch (err) {
+    assert.match(err.stderr, /Cannot use both --prod and --dev/)
+  }
+})
+
 test('runs `read`', async () => {
   const { stdout } = await cli(['read', 'some-pkg'], { cwd: path.join(fixtureDir, 'read-project') })
   assert.match(stdout, /Some Pkg Readme/)


### PR DESCRIPTION
This PR adds two new flags to the `nls deps` command to allow filtering dependencies:
- `--prod`: Shows production dependencies (including `dependencies` and `optionalDependencies`).
- `--dev`: Shows development dependencies (`devDependencies`).

These flags are mutually exclusive. If both are provided, the CLI will output an error.
The internal `deps` function in `lib/deps.js` has been updated to take a single `filter` argument instead of multiple booleans.
Comprehensive tests have been added to `test/more.spec.js` to ensure the new functionality works as expected and handles errors correctly.

---
*PR created automatically by Jules for task [14718670980629024499](https://jules.google.com/task/14718670980629024499) started by @amio*